### PR TITLE
Allowing to override the default base class

### DIFF
--- a/RazorGenerator.Core.v1/CodeTransformers/DefaultCodeTransformers.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/DefaultCodeTransformers.cs
@@ -98,7 +98,10 @@ namespace RazorGenerator.Core
 
         public override void Initialize(RazorHost razorHost, IDictionary<string, string> directives)
         {
-            razorHost.DefaultBaseClass = _typeName;
+            String baseTypeName;
+            if (!directives.TryGetValue("DefaultBaseClass", out baseTypeName))
+                baseTypeName = _typeName;
+            razorHost.DefaultBaseClass = baseTypeName;
         }
     }
 


### PR DESCRIPTION
I've seen a couple issues when overriding the base class on the `Template` transformer would be highly beneficial. Currently the only way to do that (as far as I saw) would be to create a custom transformer and change the base class passed to `SetBaseType`.

There have been other requests to do something like that in the past (e.g. [Extend Base Classes?](https://razorgenerator.codeplex.com/discussions/448226) )

This patch adds a new directive called `DefaultBaseClass` that would let you override it without any downsides, while keeping everything backwards compatible!