### PR TITLE
Include item group 'None' from MSBuild target

### DIFF
--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -12,7 +12,7 @@
     <Target Name="_ResolveRazorFiles">
         <ItemGroup>
             <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' and '%(Extension)' == '.cshtml' "
-                Include="@(Content)" />
+                Include="@(Content);@(None)" />
             <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' "
                 Include="**\*.cshtml" />
             <RazorOutputFiles


### PR DESCRIPTION
The MSBuild target now also includes the item group 'None' when collecting view source files. It is used for the build action 'None', which can be used for instance when the view file should not be deployed.

This should resolve issue #29. It's a simple change that works, and it didn't break anything when I tested. If both `Content` and `None` are empty, for whatever reason, it will still fall back on scanning the file system.