### PR TITLE
Avoid boxing in RazorTemplateBase Write & WriteTo

### DIFF
--- a/RazorGenerator.Templating/RazorTemplateBase.cs
+++ b/RazorGenerator.Templating/RazorTemplateBase.cs
@@ -82,6 +82,5 @@ namespace RazorGenerator.Templating
         public void WriteTo(TextWriter writer, float value)    { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
         public void WriteTo(TextWriter writer, double value)   { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
         public void WriteTo(TextWriter writer, decimal value)  { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
-        public void WriteTo(TextWriter writer, DateTime value) { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
     }
 }

--- a/RazorGenerator.Templating/RazorTemplateBase.cs
+++ b/RazorGenerator.Templating/RazorTemplateBase.cs
@@ -35,10 +35,12 @@ namespace RazorGenerator.Templating
             WriteLiteral(Convert.ToString(value, CultureInfo.InvariantCulture));
         }
 
-        public void Write<T>(T value) where T : IConvertible
-        {
-            WriteLiteral(value.ToString(CultureInfo.InvariantCulture));
-        }
+        public void Write(bool value)    { WriteLiteral(value.ToString()); }
+        public void Write(int value)     { WriteLiteral(value.ToString(CultureInfo.InvariantCulture)); }
+        public void Write(long value)    { WriteLiteral(value.ToString(CultureInfo.InvariantCulture)); }
+        public void Write(float value)   { WriteLiteral(value.ToString(CultureInfo.InvariantCulture)); }
+        public void Write(double value)  { WriteLiteral(value.ToString(CultureInfo.InvariantCulture)); }
+        public void Write(decimal value) { WriteLiteral(value.ToString(CultureInfo.InvariantCulture)); }
 
         public string RenderBody()
         {
@@ -74,9 +76,12 @@ namespace RazorGenerator.Templating
             writer.Write(Convert.ToString(value, CultureInfo.InvariantCulture));
         }
 
-        public void WriteTo<T>(TextWriter writer, T value) where T : IConvertible
-        {
-            writer.Write(value.ToString(CultureInfo.InvariantCulture));
-        }
+        public void WriteTo(TextWriter writer, bool value)     { writer.Write(value.ToString()); }
+        public void WriteTo(TextWriter writer, int value)      { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
+        public void WriteTo(TextWriter writer, long value)     { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
+        public void WriteTo(TextWriter writer, float value)    { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
+        public void WriteTo(TextWriter writer, double value)   { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
+        public void WriteTo(TextWriter writer, decimal value)  { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
+        public void WriteTo(TextWriter writer, DateTime value) { writer.Write(value.ToString(CultureInfo.InvariantCulture)); }
     }
 }

--- a/RazorGenerator.Templating/RazorTemplateBase.cs
+++ b/RazorGenerator.Templating/RazorTemplateBase.cs
@@ -35,6 +35,11 @@ namespace RazorGenerator.Templating
             WriteLiteral(Convert.ToString(value, CultureInfo.InvariantCulture));
         }
 
+        public void Write<T>(T value) where T : IConvertible
+        {
+            WriteLiteral(value.ToString(CultureInfo.InvariantCulture));
+        }
+
         public string RenderBody()
         {
             return _content;
@@ -67,6 +72,11 @@ namespace RazorGenerator.Templating
         public void WriteTo(TextWriter writer, object value)
         {
             writer.Write(Convert.ToString(value, CultureInfo.InvariantCulture));
+        }
+
+        public void WriteTo<T>(TextWriter writer, T value) where T : IConvertible
+        {
+            writer.Write(value.ToString(CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
The [`Write`][Write] and [`WriteTo`][WriteTo] methods of [`RazorTemplateBase`][RazorTemplateBase] cause unnecessary boxing of value types via `object` but this can be easily avoided (for a very large number of types, including all enums) via a generic overload of the same methods that constrain the type parameter to [`IConvertible`][IConvertible].

  [RazorTemplateBase]: https://github.com/RazorGenerator/RazorGenerator/blob/53e2748bf2020ef132bc017d349106df04f81806/RazorGenerator.Templating/RazorTemplateBase.cs
  [Write]: https://github.com/RazorGenerator/RazorGenerator/blob/53e2748bf2020ef132bc017d349106df04f81806/RazorGenerator.Templating/RazorTemplateBase.cs#L28
  [WriteTo]: https://github.com/RazorGenerator/RazorGenerator/blob/53e2748bf2020ef132bc017d349106df04f81806/RazorGenerator.Templating/RazorTemplateBase.cs#L67
  [IConvertible]: https://msdn.microsoft.com/en-us/library/system.iconvertible(v=vs.110).aspx