### PR TITLE
Bug: Wrong engine choice heuristics in some cases.

### DIFF
--- a/RazorGenerator.Core/HostManager.cs
+++ b/RazorGenerator.Core/HostManager.cs
@@ -52,12 +52,14 @@ namespace RazorGenerator.Core
             var directives = DirectivesParser.ParseDirectives(_baseDirectory, fullPath);
             directives["VsNamespace"] = vsNamespace;
 
-            string hostName;
             RazorRuntime runtime = _defaultRuntime;
+            var guessedHost = GuessHost(_baseDirectory, projectRelativePath, out runtime);
+
+            string hostName;
             if (!directives.TryGetValue("Generator", out hostName))
             {
                 // Determine the host and runtime from the file \ project
-                hostName = GuessHost(_baseDirectory, projectRelativePath, out runtime);
+                hostName = guessedHost;
             }
             string razorVersion;
             if (directives.TryGetValue("RazorVersion", out razorVersion))


### PR DESCRIPTION
While researching why the usings in my Web.config were not picked up by RazorEngine (see also #2 for another guy who complained about that) I saw that RazorEngine thought I'm using Razor v1 and subsequently failed to read the `RazorPagesSection` of the Web.config (there's a type mismatch then).

The problem is that the heuristic (`GuessHost`) to is only called when no Generator is specified. If it is, and in particular if it is on the *first* file processed, then the wrong core version is loaded - the default being v1.

A user can work around this simply by specifying RazorVersion whenever Generator is specified.

A crude, simple fix for the tool would be to always call `GuessHost`, which is this pull request.