### PR TITLE
Added a new directive 'Imports' which allows specifying namespace imports from razorgenerator.directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ See above for list of valid values.
 #### Add ExcludeForCodeCoverageAttribute to generated files
     @* ExcludeForCodeCoverage : true *@
 
+#### Import additional namespaces during view precompilation
+
+    @* Imports: Microsoft.Web.Mvc, MvcContrib, This.WebSite, This.WebSite.Html, HtmlHelpers.BeginCollectionItem *@
+
 As an alternative, you can create a file named `razorgenerator.directives` in the Views folder to apply directives globally. e.g. it could contain:
 
     GeneratePrettyNames: true  GenerateAbsolutePathLinePragmas: true

--- a/RazorGenerator.Core.v1/CodeTransformers/DirectivesBasedTransformers.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/DirectivesBasedTransformers.cs
@@ -14,6 +14,7 @@ namespace RazorGenerator.Core
         public static readonly string ExcludeFromCodeCoverage = "ExcludeFromCodeCoverage";
         public static readonly string SuffixFileName = "ClassSuffix";
         public static readonly string GenericParametersKey = "GenericParameters";
+        public static readonly string ImportsKey = "Imports";
         private readonly List<RazorCodeTransformerBase> _transformers = new List<RazorCodeTransformerBase>();
 
         protected override IEnumerable<RazorCodeTransformerBase> CodeTransformers
@@ -67,6 +68,13 @@ namespace RazorGenerator.Core
             {
                 var parameters = from p in genericParameters.Split(',') select p.Trim();
                 _transformers.Add(new GenericParametersTransformer(parameters));
+            }
+
+            string imports;
+            if (directives.TryGetValue(ImportsKey, out imports))
+            {
+                var values = from p in imports.Split(',') select p.Trim();
+                _transformers.Add(new SetImports(values, false));
             }
 
             base.Initialize(razorHost, directives);


### PR DESCRIPTION
This is required, at least, on mono using MVC5, as it looks like internal loading/parsing of web.config does not work.

The new directive looks like:

```
Imports: Microsoft.Web.Mvc, MvcContrib, This.WebSite, This.WebSite.Html, HtmlHelpers.BeginCollectionItem
```