### PR TITLE
Define System.Web.Mvc and System.Web.WebPages references as package dependencies

### DIFF
--- a/RazorGenerator.Mvc/RazorGenerator.Mvc.nuspec
+++ b/RazorGenerator.Mvc/RazorGenerator.Mvc.nuspec
@@ -13,11 +13,6 @@
     <dependencies>
       <dependency id="WebActivatorEx" version="2.0.3" />
     </dependencies>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Web" targetFramework="net40" />
-      <frameworkAssembly assemblyName="System.Web.Mvc" targetFramework="net40" />
-      <frameworkAssembly assemblyName="System.Web.WebPages" targetFramework="net40" />
-    </frameworkAssemblies>
     <releaseNotes>
         * v1.5.5:  Updated IsPhyicalPathsNewer to use case insensitive comparison
     </releaseNotes>

--- a/RazorGenerator.Testing/RazorGenerator.Testing.nuspec
+++ b/RazorGenerator.Testing/RazorGenerator.Testing.nuspec
@@ -10,10 +10,5 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <tags>mvc razor testing</tags>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Web" targetFramework="net40" />
-      <frameworkAssembly assemblyName="System.Web.Mvc" targetFramework="net40" />
-      <frameworkAssembly assemblyName="System.Web.WebPages" targetFramework="net40" />
-    </frameworkAssemblies>
   </metadata>
 </package>


### PR DESCRIPTION
Fixes #5. 

I removed `frameworkAssemblies` section from `.nuspec` files, so references to `System.Web.Mvc` and `System.Web.WebPages` will be resolved as `Microsoft.AspNet.*` packages from NuGet. I haven't updated version in `AssemblyInfo.cs` files though.

Did testing of built packages and it did fixed an issue mentioned in fsprojects/Paket#1338. So it seems working as expected. Double-check will be nice anyway.