### PR TITLE
Set base type from directives file

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ See above for list of valid values.
 
     @* Imports: Microsoft.Web.Mvc, MvcContrib, This.WebSite, This.WebSite.Html, HtmlHelpers.BeginCollectionItem *@
 
+#### Set BaseType during view precompilation
+    @* BaseType: This.ViewPageBase *@
+
 As an alternative, you can create a file named `razorgenerator.directives` in the Views folder to apply directives globally. e.g. it could contain:
 
     GeneratePrettyNames: true  GenerateAbsolutePathLinePragmas: true

--- a/RazorGenerator.Core.v1/CodeTransformers/DefaultCodeTransformers.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/DefaultCodeTransformers.cs
@@ -86,19 +86,28 @@ namespace RazorGenerator.Core
     public class SetBaseType : RazorCodeTransformerBase
     {
         private readonly string _typeName;
-        public SetBaseType(string typeName)
+        private readonly bool _override;
+
+        public SetBaseType(string typeName, bool @override = false)
         {
             _typeName = typeName;
+            _override = @override;
         }
 
-        public SetBaseType(Type type)
-            : this(type.FullName)
+        public SetBaseType(Type type, bool @override = false)
+            : this(type.FullName, @override: @override)
         {
+        }
+
+        private bool IsDefaultBaseClass(string baseClass)
+        {
+            return string.IsNullOrEmpty(baseClass) || typeof(System.Web.WebPages.WebPage).FullName == baseClass;
         }
 
         public override void Initialize(RazorHost razorHost, IDictionary<string, string> directives)
         {
-            razorHost.DefaultBaseClass = _typeName;
+            if (_override || IsDefaultBaseClass(razorHost.DefaultBaseClass))
+                razorHost.DefaultBaseClass = _typeName;
         }
     }
 

--- a/RazorGenerator.Core.v1/CodeTransformers/DirectivesBasedTransformers.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/DirectivesBasedTransformers.cs
@@ -15,6 +15,7 @@ namespace RazorGenerator.Core
         public static readonly string SuffixFileName = "ClassSuffix";
         public static readonly string GenericParametersKey = "GenericParameters";
         public static readonly string ImportsKey = "Imports";
+        public static readonly string BaseType = "BaseType";
         private readonly List<RazorCodeTransformerBase> _transformers = new List<RazorCodeTransformerBase>();
 
         protected override IEnumerable<RazorCodeTransformerBase> CodeTransformers
@@ -75,6 +76,12 @@ namespace RazorGenerator.Core
             {
                 var values = from p in imports.Split(',') select p.Trim();
                 _transformers.Add(new SetImports(values, false));
+            }
+
+            string baseType;
+            if (directives.TryGetValue(BaseType, out baseType))
+            {
+                _transformers.Add(new SetBaseType(baseType, @override: true));
             }
 
             base.Initialize(razorHost, directives);


### PR DESCRIPTION
This is required, at least, on mono using MVC5, setting BaseType in Views does not work on precompiling.

The razorgenerator.directives looks like:

`BaseType: This.ViewPageBase`