### PR TITLE
Fix generation of RazorOutputFiles ItemGroup with duplicated views.

### DIFF
--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -12,21 +12,25 @@
 
     <Target Name="_ResolveRazorFiles">
         <ItemGroup>
-            <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' and '%(Extension)' == '.cshtml' "
+            <RazorCsSrcFiles Condition=" '@(RazorCsSrcFiles)' == '' and '%(Extension)' == '.cshtml' "
                 Include="@(Content);@(None)" />
-            <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' "
+            <RazorCsSrcFiles Condition=" '@(RazorCsSrcFiles)' == '' "
                 Include="**\*.cshtml" />
             <RazorOutputFiles
-                Include="@(RazorSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).cs')" />
+                Include="@(RazorCsSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).cs')" />
         </ItemGroup>
-      <ItemGroup>
-        <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' and '%(Extension)' == '.vbhtml' "
-            Include="@(Content);@(None)" />
-        <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' "
-            Include="**\*.vbhtml" />
-        <RazorOutputFiles
-            Include="@(RazorSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).vb')" />
-      </ItemGroup>
+        <ItemGroup>
+            <RazorVbSrcFiles Condition=" '@(RazorVbSrcFiles)' == '' and '%(Extension)' == '.vbhtml' "
+                Include="@(Content);@(None)" />
+            <RazorVbSrcFiles Condition=" '@(RazorVbSrcFiles)' == '' "
+                Include="**\*.vbhtml" />
+            <RazorVbOutputFiles
+                Include="@(RazorVbSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).vb')" />
+         </ItemGroup>
+         <ItemGroup>
+             <RazorSrcFiles Include="@(RazorCsSrcFiles);@(RazorVbSrcFiles)" />
+             <RazorOutputFiles Include="@(RazorCsOutputFiles);@(RazorVbOutputFiles)" />
+         </ItemGroup>
     </Target>
 
     <UsingTask AssemblyFile="$(RazorGeneratorMsBuildPath)" TaskName="RazorCodeGen" />


### PR DESCRIPTION
While testing the newest NuGet release (2.4.2), I've found my builds were failing with (tons of) errors like:

`Skunk.WebSite/obj/CodeGen/Features/Account/AccountEnroll.cshtml.vb' could not be found

After inspecting msbuild's output in detail, I've found that every view in my proyect was being passed as twice to csc's command line, first with .cshtml.cs extension, and them with .cshtml.vb.

It looks like recent VB support (#85) introduced a regression into RazorGenerator.MSBuild.targets, by which RazorOutputFiles ItemGroup was invoked twice, frist for CS files, then for VB, thus, overwritting the initial (CS) declaration.

This pull-req changes RazorGenerator.MSBuild.targets, so it accounts for each kind of view (CS vs VB) separatelly, and emitting RazorSrcFiles && RazorOutputFiles as an union/concat of filepaths of each kind.