### PR TITLE
Fixed NRE in WebPagesTransformer in method ProcessGeneratedCode

### DIFF
--- a/RazorGenerator.Core.v1/CodeTransformers/AggregateCodeTransformer.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/AggregateCodeTransformer.cs
@@ -13,6 +13,8 @@ namespace RazorGenerator.Core
 
         public override void Initialize(RazorHost razorHost, IDictionary<string, string> directives)
         {
+            base.Initialize(razorHost, directives);
+
             foreach (var transformer in CodeTransformers)
             {
                 transformer.Initialize(razorHost, directives);


### PR DESCRIPTION
The `_razorHost` was never initialized in Initialize method.

I have no idea **how your tests are green**. The moment I downloaded the source and run them locally, the WebPages & helper tests failed.