### PR TITLE
Set priority to Web.config BaseType VS default value

### DIFF
--- a/RazorGenerator.Core.v1/CodeTransformers/MvcWebConfigTransformer.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/MvcWebConfigTransformer.cs
@@ -51,7 +51,7 @@ namespace RazorGenerator.Core
                     string baseType = section.PageBaseType;
                     if (!DefaultBaseType.Equals(baseType, StringComparison.OrdinalIgnoreCase))
                     {
-                        _transformers.Add(new SetBaseType(baseType));
+                        _transformers.Add(new SetBaseType(baseType, @override: true));
                     }
 
                     if (section != null)


### PR DESCRIPTION
This Fix solve #92 priority issue with pageBaseType specified in the ~/Views/Web.config and razorgenerator.directives, using the pageBaseType of Web.Config if this is != default (System.Web.Mvc.WebViewPage)