### PR TITLE
Expose ViewEngine to allow additional view engines when testing

### DIFF
--- a/RazorGenerator.Testing/WebViewPageExtensions.cs
+++ b/RazorGenerator.Testing/WebViewPageExtensions.cs
@@ -24,6 +24,11 @@ namespace RazorGenerator.Testing
 
         private static readonly Dictionary<string, ViewPlaceholder> _views = new Dictionary<string, ViewPlaceholder>();
 
+        public static IViewEngine ViewEngine
+        {
+            get { return _viewEngine; }
+        }
+
         public static string Render<TModel>(this WebViewPage<TModel> view, TModel model = default(TModel))
         {
             return Render<TModel>(view, null, model);


### PR DESCRIPTION
Allows testing child actions and other generated views.