### PR TITLE
Use "Func<boo>" instead of bool as the engine property's return type to avoid issues about null of HttpContext when it used.

### DIFF
--- a/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
+++ b/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
@@ -103,7 +103,7 @@ namespace RazorGenerator.Mvc
         {
             virtualPath = EnsureVirtualPathPrefix(virtualPath);
 
-            if (UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
+            if (UsePhysicalViewsIfNewer != null && UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
             {
                 // If the physical file on disk is newer and the user's opted in this behavior, serve it instead.
                 return false;
@@ -140,13 +140,13 @@ namespace RazorGenerator.Mvc
             virtualPath = EnsureVirtualPathPrefix(virtualPath);
             Type type;
 
-            if (!PreemptPhysicalFiles() && VirtualPathProvider.FileExists(virtualPath))
+            if (PreemptPhysicalFiles != null && !PreemptPhysicalFiles() && VirtualPathProvider.FileExists(virtualPath))
             {
                 // If we aren't pre-empting physical files, use the BuildManager to create _ViewStart instances if the file exists on disk. 
                 return BuildManager.CreateInstanceFromVirtualPath(virtualPath, typeof(WebPageRenderingBase));
             }
 
-            if (UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
+            if (UsePhysicalViewsIfNewer != null && UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
             {
                 // If the physical file on disk is newer and the user's opted in this behavior, serve it instead.
                 return BuildManager.CreateInstanceFromVirtualPath(virtualPath, typeof(WebViewPage));

--- a/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
+++ b/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
@@ -83,7 +83,7 @@ namespace RazorGenerator.Mvc
         /// <summary>
         /// Determines if IVirtualPathFactory lookups returns files from assembly regardless of whether physical files are available for the virtual path.
         /// </summary>
-        public bool PreemptPhysicalFiles
+        public Func<bool> PreemptPhysicalFiles
         {
             get; set;
         }
@@ -94,7 +94,7 @@ namespace RazorGenerator.Mvc
         /// <remarks>
         /// What an awful name!
         /// </remarks>
-        public bool UsePhysicalViewsIfNewer
+        public Func<bool> UsePhysicalViewsIfNewer
         {
             get; set;
         }
@@ -103,7 +103,7 @@ namespace RazorGenerator.Mvc
         {
             virtualPath = EnsureVirtualPathPrefix(virtualPath);
 
-            if (UsePhysicalViewsIfNewer && IsPhysicalFileNewer(virtualPath))
+            if (UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
             {
                 // If the physical file on disk is newer and the user's opted in this behavior, serve it instead.
                 return false;
@@ -140,13 +140,13 @@ namespace RazorGenerator.Mvc
             virtualPath = EnsureVirtualPathPrefix(virtualPath);
             Type type;
 
-            if (!PreemptPhysicalFiles && VirtualPathProvider.FileExists(virtualPath))
+            if (!PreemptPhysicalFiles() && VirtualPathProvider.FileExists(virtualPath))
             {
                 // If we aren't pre-empting physical files, use the BuildManager to create _ViewStart instances if the file exists on disk. 
                 return BuildManager.CreateInstanceFromVirtualPath(virtualPath, typeof(WebPageRenderingBase));
             }
 
-            if (UsePhysicalViewsIfNewer && IsPhysicalFileNewer(virtualPath))
+            if (UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
             {
                 // If the physical file on disk is newer and the user's opted in this behavior, serve it instead.
                 return BuildManager.CreateInstanceFromVirtualPath(virtualPath, typeof(WebViewPage));

--- a/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
+++ b/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
@@ -103,7 +103,7 @@ namespace RazorGenerator.Mvc
         {
             virtualPath = EnsureVirtualPathPrefix(virtualPath);
 
-            if (UsePhysicalViewsIfNewer != null && UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
+            if (UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
             {
                 // If the physical file on disk is newer and the user's opted in this behavior, serve it instead.
                 return false;
@@ -140,13 +140,13 @@ namespace RazorGenerator.Mvc
             virtualPath = EnsureVirtualPathPrefix(virtualPath);
             Type type;
 
-            if (PreemptPhysicalFiles != null && !PreemptPhysicalFiles() && VirtualPathProvider.FileExists(virtualPath))
+            if (!PreemptPhysicalFiles() && VirtualPathProvider.FileExists(virtualPath))
             {
                 // If we aren't pre-empting physical files, use the BuildManager to create _ViewStart instances if the file exists on disk. 
                 return BuildManager.CreateInstanceFromVirtualPath(virtualPath, typeof(WebPageRenderingBase));
             }
 
-            if (UsePhysicalViewsIfNewer != null && UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
+            if (UsePhysicalViewsIfNewer() && IsPhysicalFileNewer(virtualPath))
             {
                 // If the physical file on disk is newer and the user's opted in this behavior, serve it instead.
                 return BuildManager.CreateInstanceFromVirtualPath(virtualPath, typeof(WebViewPage));

--- a/RazorGenerator.Mvc/RazorGenerator.Mvc.csproj
+++ b/RazorGenerator.Mvc/RazorGenerator.Mvc.csproj
@@ -41,29 +41,29 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=3.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.3.0.50813.1\lib\net40\System.Web.Mvc.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.40804.0\lib\net40\System.Web.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.1.0.20105.408\lib\net40\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Deployment, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/RazorGenerator.Mvc/RazorGenerator.Mvc.csproj
+++ b/RazorGenerator.Mvc/RazorGenerator.Mvc.csproj
@@ -41,29 +41,29 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Mvc, Version=3.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.40804.0\lib\net40\System.Web.Mvc.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.3.0.50813.1\lib\net40\System.Web.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.1.0.20105.408\lib\net40\System.Web.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages.Deployment, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
When create the engine from Applciation_Start and used HttpContext to
set engine's property for some reason we'll get exception about null of
HttpContext, and use "Func<boo>" instead of bool as the engine property's
return type will avoid the issue.