### PR TITLE
Fix for having only cshtml or vbhtml (but not both) as well as node_modules

### DIFF
--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -12,18 +12,18 @@
 
     <Target Name="_ResolveRazorFiles">
         <ItemGroup>
+             <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' and ('%(Extension)' == '.cshtml' or '%(Extension)' == '.vbhtml') " Include="@(Content);@(None)" />
+             <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' " Include="**\*.vbhtml;**\*.cshtml" />
+        </ItemGroup>
+        <ItemGroup>
             <RazorCsSrcFiles Condition=" '@(RazorCsSrcFiles)' == '' and '%(Extension)' == '.cshtml' "
-                Include="@(Content);@(None)" />
-            <RazorCsSrcFiles Condition=" '@(RazorCsSrcFiles)' == '' "
-                Include="**\*.cshtml" />
+                Include="@(RazorSrcFiles)" />
             <RazorOutputFiles
                 Include="@(RazorCsSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).cs')" />
         </ItemGroup>
         <ItemGroup>
             <RazorVbSrcFiles Condition=" '@(RazorVbSrcFiles)' == '' and '%(Extension)' == '.vbhtml' "
-                Include="@(Content);@(None)" />
-            <RazorVbSrcFiles Condition=" '@(RazorVbSrcFiles)' == '' "
-                Include="**\*.vbhtml" />
+                Include="@(RazorSrcFiles)" />
             <RazorVbOutputFiles
                 Include="@(RazorVbSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).vb')" />
          </ItemGroup>


### PR DESCRIPTION
Fixes that when you have node_modules in your project (paths too long for Win32 APIs) and also no vbhtml files, you get 'illegal characters in path'

The fix works by combining resolution of cshtml and vbhtml from a parent ItemGroup so that the fallback **\*.cshtml/vbhtml is not used if _either_ cshtml or vbhtml are present in the project.

e.g. first we grab all cshtml and vbhtml together, then the existing item groups filter that result to separate them.

This should fix #99 (see also my comment there)