### PR TITLE
Update project file with the new precompiled views generated during MSBuild task

### DIFF
--- a/RazorGenerator.Core/CodeLanguageUtil.cs
+++ b/RazorGenerator.Core/CodeLanguageUtil.cs
@@ -39,6 +39,7 @@ namespace RazorGenerator.Core
         public abstract string BuildGenericTypeReference(string GenericType, IEnumerable<string> GenericArguments);
         public abstract bool IsGenericTypeReference(string TypeName);
         public abstract string GetCodeFileExtension();
+        public abstract string GetProjectFileExtension();
         public abstract string GetPreGeneratedCodeBlock();
         public abstract string GetPostGeneratedCodeBlock();
         public abstract System.CodeDom.Compiler.CodeDomProvider GetCodeDomProvider();

--- a/RazorGenerator.Core/CodeLanguageUtils/CSharpCodeLanguageUtil.cs
+++ b/RazorGenerator.Core/CodeLanguageUtils/CSharpCodeLanguageUtil.cs
@@ -59,6 +59,11 @@ namespace RazorGenerator.Core.CodeLanguageUtils
             return ".cs";
         }
 
+        public override string GetProjectFileExtension()
+        {
+            return ".csproj";
+        }
+
         public override string GetPostGeneratedCodeBlock()
         {
             return "#pragma warning restore 1591";

--- a/RazorGenerator.Core/CodeLanguageUtils/VBCodeLanguageUtil.cs
+++ b/RazorGenerator.Core/CodeLanguageUtils/VBCodeLanguageUtil.cs
@@ -45,6 +45,11 @@ namespace RazorGenerator.Core.CodeLanguageUtils
             return ".vb";
         }
 
+        public override string GetProjectFileExtension()
+        {
+            return ".vbproj";
+        }
+
         public override string GetPostGeneratedCodeBlock()
         {
             return "";

--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -6,6 +6,7 @@
         <PrecompileRazorFiles Condition=" '$(PrecompileRazorFiles)' == '' ">true</PrecompileRazorFiles>
         <RazorGeneratorMsBuildPath Condition=" '$(RazorGeneratorMsBuildPath)' == '' ">$(MSBuildThisFileDirectory)\..\tools\RazorGenerator.MsBuild.dll</RazorGeneratorMsBuildPath>
         <RazorViewsCodeGenDirectory Condition=" '$(RazorViewsCodeGenDirectory)' == '' ">$(MsBuildProjectDirectory)\obj\CodeGen\</RazorViewsCodeGenDirectory>
+        <IncludeNewViewsInProject Condition=" '$(IncludeNewViewsInProject)' == '' ">false</IncludeNewViewsInProject>
       
         <CompileDependsOn Condition=" '$(PrecompileRazorFiles)' == 'true' ">
             PrecompileRazorFiles;
@@ -44,7 +45,9 @@
         <RazorCodeGen ProjectRoot="$(MsBuildProjectDirectory)"
                                     FilesToPrecompile="@(RazorSrcFiles)"
                                     CodeGenDirectory="$(RazorViewsCodeGenDirectory)"
-                                    RootNamespace="$(RootNamespace)">
+                                    RootNamespace="$(RootNamespace)"
+                                    ProjectName="$(MsBuildProjectName)"
+                                    IncludeNewViewsInProject="$(IncludeNewViewsInProject)">
             <Output TaskParameter="GeneratedFiles" ItemName="FilesGenerated" />
         </RazorCodeGen>
         <ItemGroup>


### PR DESCRIPTION
If we set the "IncludeNewViewsInProject" property to true and the CodeGenDirectory is equal to the ProjectRoot, the RazorGenerator MSBuild task will update the project file (*.csproj/*.vbproj), adding the new precompiled views inside.