### PR TITLE
Fix typo RazorOutputFiles to RazorCsOutputFiles

### DIFF
--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -21,7 +21,7 @@
         <ItemGroup>
             <RazorCsSrcFiles Condition=" '@(RazorCsSrcFiles)' == '' and '%(Extension)' == '.cshtml' "
                 Include="@(RazorSrcFiles)" />
-            <RazorOutputFiles
+          <RazorCsOutputFiles
                 Include="@(RazorCsSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).cs')" />
         </ItemGroup>
         <ItemGroup>


### PR DESCRIPTION
Fixes typo in target. The RazorCsOutputFiles is used further down the file to populate RazorOutputFiles.