### PR TITLE
example of error when using yield to return an IEnumerable<something>

### DIFF
--- a/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
+++ b/RazorGenerator.Mvc/PrecompiledMvcEngine.cs
@@ -170,6 +170,12 @@ namespace RazorGenerator.Mvc
 
         internal static bool IsPhysicalFileNewer(string virtualPath, string baseVirtualPath, Lazy<DateTime> assemblyLastWriteTime)
         {
+            // potential fix 
+            //if (virtualPath.Contains("<"))
+            //{
+            //    return false;
+            //}
+
             if (virtualPath.StartsWith(baseVirtualPath ?? String.Empty, StringComparison.OrdinalIgnoreCase))
             {
                 // If a base virtual path is specified, we should remove it as a prefix. Everything that follows should map to a view file on disk.

--- a/samples/MvcSample/Controllers/HomeController.cs
+++ b/samples/MvcSample/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Web.Mvc;
 using RazorGenerator.Mvc;
 
@@ -31,6 +32,21 @@ namespace MvcSample.Controllers
         public ActionResult About()
         {
             return View();
+        }
+
+        public ActionResult Yield()
+        {
+            IEnumerable<int> model = YieldRows(); // using 'ToList' makes error go away .ToList();
+
+            return View(model);
+        }
+
+        private IEnumerable<int> YieldRows()
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                yield return i;
+            }
         }
 
         [HttpPost]

--- a/samples/MvcSample/MvcSample.csproj
+++ b/samples/MvcSample/MvcSample.csproj
@@ -159,6 +159,9 @@
   <ItemGroup>
     <Content Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Home\Yield.cshtml" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/samples/MvcSample/Views/Home/Index.cshtml
+++ b/samples/MvcSample/Views/Home/Index.cshtml
@@ -4,16 +4,7 @@
     ViewBag.Title = "Home Page";
 }
 
-<h2>@ViewBag.Message</h2>
+<h2>I found an error when I was returning a list using 'yield'</h2>
 <p>
-    To learn more about ASP.NET MVC visit <a href="http://asp.net/mvc" title="ASP.NET MVC Website">http://asp.net/mvc</a>.
+    @Html.ActionLink("Click on this link to view the error ", "Yield")
 </p>
-
-<h3>Precompiled helper sample</h3>
-@Html.ActionLink("Helper Demo", "HelperDemo", "Home") 
-
-<h3>Precompiled view sample: </h3>
-@RenderPage("~/Views/Shared/_ViewTypes.cshtml")
-
-<h3>Pluggable area</h3>
-@Html.ActionLink("Pluggable area", "Index", "Foo", new { area = "MyPluggableArea" }, null) 

--- a/samples/MvcSample/Views/Home/Yield.cshtml
+++ b/samples/MvcSample/Views/Home/Yield.cshtml
@@ -1,0 +1,3 @@
+﻿@model IEnumerable<int>
+    
+@Html.EditorForModel()


### PR DESCRIPTION
I came across this error when using RazorGenerator in my own project, and I've narrowed it down to a problem when using yield to return a IEnumerable.  The viewpath that is passed through contains illegal characters, which are angle brackets.  Calling ToList is a solution, which I will use in my application, but if the is a fix that can be applied to RazorGenerator it may save others some headaches.