### PR TITLE
MsBuild: get rid of unneeded rebuilds

### DIFF
--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -6,50 +6,56 @@
         <PrecompileRazorFiles Condition=" '$(PrecompileRazorFiles)' == '' ">true</PrecompileRazorFiles>
         <RazorGeneratorMsBuildPath Condition=" '$(RazorGeneratorMsBuildPath)' == '' ">$(MSBuildThisFileDirectory)\..\tools\RazorGenerator.MsBuild.dll</RazorGeneratorMsBuildPath>
         <RazorViewsCodeGenDirectory Condition=" '$(RazorViewsCodeGenDirectory)' == '' ">$(MsBuildProjectDirectory)\obj\CodeGen\</RazorViewsCodeGenDirectory>
-      
+
         <CompileDependsOn Condition=" '$(PrecompileRazorFiles)' == 'true' ">
-            PrecompileRazorFiles;
+            IncludeRazorFilesIntoCompilation;
             $(CompileDependsOn);
         </CompileDependsOn>
     </PropertyGroup>
 
     <Target Name="_ResolveRazorFiles">
         <ItemGroup>
-             <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' and ('%(Extension)' == '.cshtml' or '%(Extension)' == '.vbhtml') " Include="@(Content);@(None)" />
-             <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' " Include="**\*.vbhtml;**\*.cshtml" />
+            <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' and ('%(Extension)' == '.cshtml' or '%(Extension)' == '.vbhtml') " Include="@(Content);@(None)" />
+            <RazorSrcFiles Condition=" '@(RazorSrcFiles)' == '' " Include="**\*.vbhtml;**\*.cshtml" />
         </ItemGroup>
         <ItemGroup>
             <RazorCsSrcFiles Condition=" '@(RazorCsSrcFiles)' == '' and '%(Extension)' == '.cshtml' "
-                Include="@(RazorSrcFiles)" />
-            <RazorOutputFiles
-                Include="@(RazorCsSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).cs')" />
+                Include="@(RazorSrcFiles)">
+                <OutputExtension>.cs</OutputExtension>
+            </RazorCsSrcFiles>
+            <RazorCsOutputFiles
+                Include="@(RazorCsSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension)%(OutputExtension)')" />
         </ItemGroup>
         <ItemGroup>
             <RazorVbSrcFiles Condition=" '@(RazorVbSrcFiles)' == '' and '%(Extension)' == '.vbhtml' "
-                Include="@(RazorSrcFiles)" />
+                Include="@(RazorSrcFiles)">
+                <OutputExtension>.vb</OutputExtension>
+            </RazorVbSrcFiles>
             <RazorVbOutputFiles
-                Include="@(RazorVbSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension).vb')" />
-         </ItemGroup>
-         <ItemGroup>
-             <RazorSrcFiles Include="@(RazorCsSrcFiles);@(RazorVbSrcFiles)" />
-             <RazorOutputFiles Include="@(RazorCsOutputFiles);@(RazorVbOutputFiles)" />
-         </ItemGroup>
+                Include="@(RazorVbSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension)%(OutputExtension)')" />
+        </ItemGroup>
+        <ItemGroup>
+            <RazorFinalSrcFiles Include="@(RazorCsSrcFiles);@(RazorVbSrcFiles)" />
+            <RazorOutputFiles Include="@(RazorCsOutputFiles);@(RazorVbOutputFiles)" />
+        </ItemGroup>
     </Target>
 
     <UsingTask AssemblyFile="$(RazorGeneratorMsBuildPath)" TaskName="RazorCodeGen" />
     <Target Name="PrecompileRazorFiles"
                     DependsOnTargets="_ResolveRazorFiles"
-                    Inputs="@(RazorSrcFiles)"
-                    Outputs="@(RazorOutputFiles)">
+                    Inputs="@(RazorFinalSrcFiles)"
+                    Outputs="@(RazorFinalSrcFiles -> '$(RazorViewsCodeGenDirectory)%(RelativeDir)%(Filename)%(Extension)%(OutputExtension)')">
         <RazorCodeGen ProjectRoot="$(MsBuildProjectDirectory)"
-                                    FilesToPrecompile="@(RazorSrcFiles)"
+                                    FilesToPrecompile="@(RazorFinalSrcFiles)"
                                     CodeGenDirectory="$(RazorViewsCodeGenDirectory)"
                                     RootNamespace="$(RootNamespace)">
             <Output TaskParameter="GeneratedFiles" ItemName="FilesGenerated" />
         </RazorCodeGen>
+    </Target>
+
+    <Target Name="IncludeRazorFilesIntoCompilation" DependsOnTargets="PrecompileRazorFiles">
         <ItemGroup>
-          <Compile Include="@(FilesGenerated)" Condition=" '@(RazorOutputFiles)' == '' "/>
-          <Compile Include="@(RazorOutputFiles)" />
+            <Compile Include="@(RazorOutputFiles)" />
         </ItemGroup>
     </Target>
 </Project>


### PR DESCRIPTION
Fix MsBuild's change detection to get rid of unneeded project rebuilds.

MsBuild can match inputs and outputs one-to-one, but for this to work transform must be put directly into `Outputs` parameter of the target.

This change caused `Compile` items in the target to be added twice so they were moved to a separate target which works fine.

Before this change project would rebuild on every build because `PageA.cshtml` is always newer than `PageB.cshtml.cs`:
```
1>Building target "PrecompileRazorFiles" completely.
1>Input file "PageA.cshtml" is newer than output file "C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageB.cshtml.cs".
1>Using "RazorCodeGen" task from assembly "C:\Projects\RazorExample\packages\RazorGenerator.MsBuild.2.5.0\build\\..\tools\RazorGenerator.MsBuild.dll".
1>Task "RazorCodeGen" (TaskId:17)
1>  Task Parameter:ProjectRoot=C:\Projects\RazorExample\PrecompiledPages (TaskId:17)
1>  Task Parameter:
1>      FilesToPrecompile=
1>          PageA.cshtml
1>          PageB.cshtml
1>          PageC.cshtml
1>          PageA.cshtml
1>          PageB.cshtml
1>          PageC.cshtml (TaskId:17)
1>  Task Parameter:CodeGenDirectory=C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\ (TaskId:17)
1>  Task Parameter:RootNamespace=PrecompiledPages (TaskId:17)
1>  Precompiling C:\Projects\RazorExample\PrecompiledPages\PageA.cshtml at path C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageA.cshtml.cs (TaskId:17)
1>  Skipping file C:\Projects\RazorExample\PrecompiledPages\PageB.cshtml since C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageB.cshtml.cs is already up to date (TaskId:17)
1>  Skipping file C:\Projects\RazorExample\PrecompiledPages\PageC.cshtml since C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageC.cshtml.cs is already up to date (TaskId:17)
1>  Skipping file C:\Projects\RazorExample\PrecompiledPages\PageA.cshtml since C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageA.cshtml.cs is already up to date (TaskId:17)
1>  Skipping file C:\Projects\RazorExample\PrecompiledPages\PageB.cshtml since C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageB.cshtml.cs is already up to date (TaskId:17)
1>  Skipping file C:\Projects\RazorExample\PrecompiledPages\PageC.cshtml since C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageC.cshtml.cs is already up to date (TaskId:17)
1>  Output Item(s): 
1>      FilesGenerated=
1>          C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageA.cshtml.cs
1>                  AutoGen=true
1>                  DependentUpon=fileName (TaskId:17)
1>Done executing task "RazorCodeGen". (TaskId:17)
```

And after:
```
1>Building target "PrecompileRazorFiles" partially, because some output files are out of date with respect to their input files.
1>[RazorFinalSrcFiles: Input=PageA.cshtml, Output=C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageA.cshtml.cs] Input file is newer than output file.
1>Using "RazorCodeGen" task from assembly "C:\Projects\RazorExample\packages\RazorGenerator.MsBuild.2.5.0\build\\..\tools\RazorGenerator.MsBuild.dll".
1>Task "RazorCodeGen" (TaskId:17)
1>  Task Parameter:ProjectRoot=C:\Projects\RazorExample\PrecompiledPages (TaskId:17)
1>  Task Parameter:
1>      FilesToPrecompile=
1>          PageA.cshtml
1>                  OutputExtension=.cs (TaskId:17)
1>  Task Parameter:CodeGenDirectory=C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\ (TaskId:17)
1>  Task Parameter:RootNamespace=PrecompiledPages (TaskId:17)
1>  Precompiling C:\Projects\RazorExample\PrecompiledPages\PageA.cshtml at path C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageA.cshtml.cs (TaskId:17)
1>  Output Item(s): 
1>      FilesGenerated=
1>          C:\Projects\RazorExample\PrecompiledPages\obj\CodeGen\PageA.cshtml.cs
1>                  AutoGen=true
1>                  DependentUpon=fileName (TaskId:17)
1>Done executing task "RazorCodeGen". (TaskId:17)
```