### PR TITLE
Prevent error 'Specified argument was out of the range of valid value…

### DIFF
--- a/RazorGenerator.Core.v1/CodeTransformers/MvcWebConfigTransformer.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/MvcWebConfigTransformer.cs
@@ -44,7 +44,7 @@ namespace RazorGenerator.Core
 
             try
             {
-                var config = WebConfigurationManager.OpenMappedWebConfiguration(configFileMap, directoryVirtualPath);
+                var config = WebConfigurationManager.OpenMappedWebConfiguration(configFileMap, directoryVirtualPath, System.Web.Hosting.HostingEnvironment.ApplicationHost.GetSiteName());
                 RazorPagesSection section = config.GetSection(RazorPagesSection.SectionName) as RazorPagesSection;
                 if (section != null)
                 {


### PR DESCRIPTION
…s. Parameter name: site'

The error occurs at System.Web.Configuration.WebConfigurationHost.InitForConfiguration when it is reading configuration.