### PR TITLE
added directive CustomAreaName to allow custom area name for asp.net …

### DIFF
--- a/RazorGenerator.Core.v1/CodeTransformers/AddPageVirtualPathAttribute.cs
+++ b/RazorGenerator.Core.v1/CodeTransformers/AddPageVirtualPathAttribute.cs
@@ -9,13 +9,23 @@ namespace RazorGenerator.Core
     public class AddPageVirtualPathAttribute : RazorCodeTransformerBase
     {
         private const string VirtualPathDirectiveKey = "VirtualPath";
+        private const string MvcAreaNameDirectiveKey = "CustomAreaName";
         private string _projectRelativePath;
         private string _overriddenVirtualPath;
+        private string _customAreaName;
 
         public override void Initialize(RazorHost razorHost, IDictionary<string, string> directives)
         {
             _projectRelativePath = razorHost.ProjectRelativePath;
             directives.TryGetValue(VirtualPathDirectiveKey, out _overriddenVirtualPath);
+            if (directives.TryGetValue(MvcAreaNameDirectiveKey, out _customAreaName))
+            {
+                _customAreaName = string.Format("Areas/{0}/", _customAreaName);
+            }
+            else
+            {
+                _customAreaName = string.Empty;
+            }
         }
 
         public override void ProcessGeneratedCode(CodeCompileUnit codeCompileUnit, CodeNamespace generatedNamespace, CodeTypeDeclaration generatedClass, CodeMemberMethod executeMethod)
@@ -24,7 +34,7 @@ namespace RazorGenerator.Core
             string virtualPath;
             try
             {
-                virtualPath = _overriddenVirtualPath ?? VirtualPathUtility.ToAppRelative("~/" + _projectRelativePath.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                virtualPath = _overriddenVirtualPath ?? VirtualPathUtility.ToAppRelative("~/" + _customAreaName + _projectRelativePath.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
             }
             catch (HttpException)
             {


### PR DESCRIPTION
This PR also add a new directive CustomAreaName so that the Area name for the whole project. In our setup for MVC we have many project inside Areas folder of the main project and the project names are the area names. This was the most convenient setup we could find to support development (build/debug) and deployment.
Please see this article, Step 6 for more information. Our setup is similar
https://medium.com/@info_nishant/how-to-create-a-modular-web-application-in-c-mvc-85d8074a26bc
Thank you,
Nam