### PR TITLE
Add VS2026 (v18.x) support alongside VS2022

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -33,7 +33,7 @@
        <PackageOutputDir Condition="$(PackageOutputDir) == ''">$([System.IO.Path]::GetFullPath('$(MsBuildThisFileDirectory)..\artifacts'))</PackageOutputDir>
 
         <!-- Commands -->
-       <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -p Configuration=$(Configuration) -o "$(PackageOutputDir)" -symbols $(BuildPackageFlags)</BuildCommand>
+       <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -p Configuration=$(Configuration) -OutputDirectory "$(PackageOutputDir)" -symbols $(BuildPackageFlags)</BuildCommand>
 
        <!-- Make the build depend on restore packages -->
        <BuildDependsOn Condition="$(BuildPackage) == 'true'">

--- a/RazorGenerator.Core.Test/CoreTest.cs
+++ b/RazorGenerator.Core.Test/CoreTest.cs
@@ -10,6 +10,59 @@ namespace RazorGenerator.Core.Test
 {
     public class CoreTest
     {
+        // Each Razor runtime version (v1/v2/v3) was compiled against a different
+        // generation of System.Web.Razor / System.Web.Mvc / System.Web.WebPages.
+        // The DLLs for v1 (Razor 1, MVC 3) and v2 (Razor 2, MVC 4) are placed in
+        // "v1\" and "v2\" sub-directories next to the test assembly so they can
+        // coexist with the v3 DLLs (Razor 3, MVC 5) in the main output directory.
+        // The AssemblyResolve handler below steers the CLR to the correct sub-dir
+        // rather than relying on app.config probing (which xunit 2.1 MSBuild runner
+        // may not honour because it runs tests in-process).
+        static CoreTest()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += ResolveVersionedWebAssembly;
+        }
+
+        private static Assembly ResolveVersionedWebAssembly(object sender, ResolveEventArgs args)
+        {
+            var requested = new AssemblyName(args.Name);
+            // Only intercept the ASP.NET web stack assemblies that differ across Razor runtimes.
+            var webAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "System.Web.Razor",
+                "System.Web.Mvc",
+                "System.Web.WebPages",
+                "System.Web.WebPages.Razor",
+                "Microsoft.Web.Infrastructure"
+            };
+            if (!webAssemblies.Contains(requested.Name))
+                return null;
+
+            // Determine which versioned sub-directory to look in.
+            int majorVersion = requested.Version != null ? requested.Version.Major : 0;
+            string subDir;
+
+            // System.Web.Mvc 3.x → v1, 4.x → v2
+            if (requested.Name.Equals("System.Web.Mvc", StringComparison.OrdinalIgnoreCase))
+                subDir = majorVersion == 3 ? "v1" : majorVersion == 4 ? "v2" : null;
+            // Microsoft.Web.Infrastructure 1.x → v1
+            else if (requested.Name.Equals("Microsoft.Web.Infrastructure", StringComparison.OrdinalIgnoreCase))
+                subDir = "v1";
+            // System.Web.Razor, System.Web.WebPages, System.Web.WebPages.Razor: 1.x → v1, 2.x → v2
+            else
+                subDir = majorVersion == 1 ? "v1" : majorVersion == 2 ? "v2" : null;
+
+            if (subDir == null)
+                return null;
+
+            string outputDir = Path.GetDirectoryName(new Uri(typeof(CoreTest).Assembly.CodeBase).LocalPath);
+            string dllPath = Path.Combine(outputDir, subDir, requested.Name + ".dll");
+            if (File.Exists(dllPath))
+                return Assembly.LoadFrom(dllPath);
+
+            return null;
+        }
+
         private static readonly string[] _testNames = new[] 
         { 
             "WebPageTest",

--- a/RazorGenerator.Core.Test/RazorGenerator.Core.Test.csproj
+++ b/RazorGenerator.Core.Test/RazorGenerator.Core.Test.csproj
@@ -43,6 +43,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -214,6 +218,7 @@
     <EmbeddedResource Include="TestFiles\Output_v2\TemplateWithGenericParametersTest.txt" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -235,7 +240,32 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <!-- Copy app.config as AssemblyName.dll.config so xunit AppDomain picks up binding redirects and probing paths -->
+    <Copy SourceFiles="app.config" DestinationFiles="$(OutputPath)$(AssemblyName).dll.config" />
+
+    <!-- Copy Razor v1 / MVC 3 era DLLs into the v1\ subdirectory so they can be     -->
+    <!-- probed independently without conflicting with the Razor 3 / MVC 5 DLLs.    -->
+    <MakeDir Directories="$(OutputPath)v1" />
+    <ItemGroup>
+      <V1Dlls Include="..\packages\Microsoft.AspNet.Razor.1.0.20105.408\lib\net40\System.Web.Razor.dll" />
+      <V1Dlls Include="..\packages\Microsoft.AspNet.Mvc.3.0.20105.1\lib\net40\System.Web.Mvc.dll" />
+      <V1Dlls Include="..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.dll" />
+      <V1Dlls Include="..\packages\Microsoft.AspNet.WebPages.1.0.20105.408\lib\net40\System.Web.WebPages.Razor.dll" />
+      <V1Dlls Include="..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(V1Dlls)" DestinationFolder="$(OutputPath)v1" />
+
+    <!-- Copy Razor v2 / MVC 4 era DLLs into the v2\ subdirectory for the same reason. -->
+    <MakeDir Directories="$(OutputPath)v2" />
+    <ItemGroup>
+      <V2Dlls Include="..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll" />
+      <V2Dlls Include="..\packages\Microsoft.AspNet.Mvc.4.0.20710.0\lib\net40\System.Web.Mvc.dll" />
+      <V2Dlls Include="..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll" />
+      <V2Dlls Include="..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll" />
+      <V2Dlls Include="..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(V2Dlls)" DestinationFolder="$(OutputPath)v2" />
+  </Target>
 </Project>

--- a/RazorGenerator.Core.Test/app.config
+++ b/RazorGenerator.Core.Test/app.config
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <!-- Allow the CLR to find v1 (Razor 1, MVC 3) and v2 (Razor 2, MVC 4) DLLs
+           in their respective subdirectories, so they don't conflict with v3 in the
+           main output directory. -->
+      <probing privatePath="v1;v2" />
+      <!-- Redirect MVC 4/5 range to the MVC5 assembly present in main dir -->
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="4.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <!-- Redirect WebPages.Razor v2/v3 to v3 (main dir has v3) -->
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="2.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <!-- Redirect WebPages v2/v3 to v3 -->
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="2.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <!-- Redirect Razor v2 to v3 (main dir has v3) -->
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="2.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>
+

--- a/RazorGenerator.Core.Test/packages.config
+++ b/RazorGenerator.Core.Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/RazorGenerator.Tooling.sln
+++ b/RazorGenerator.Tooling.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30410.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.0.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RazorGenerator.Core", "RazorGenerator.Core\RazorGenerator.Core.csproj", "{AF040852-112F-494D-B1D0-B50888928DB6}"
 EndProject

--- a/RazorGenerator.Tooling/RazorGenerator.Tooling.csproj
+++ b/RazorGenerator.Tooling/RazorGenerator.Tooling.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -58,73 +58,70 @@
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net46\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ServiceHub.Analyzers, Version=3.0.1039.21923, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ServiceHub.Analyzers.3.0.1039-alpha\lib\net472\analyzers\Microsoft.ServiceHub.Analyzers.dll</HintPath>
+    <Reference Include="Microsoft.ServiceHub.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ServiceHub.Client.4.1.3102\lib\net472\Microsoft.ServiceHub.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ServiceHub.Client, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ServiceHub.Client.3.0.1039-alpha\lib\net472\Microsoft.ServiceHub.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ServiceHub.Framework, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ServiceHub.Framework.3.0.1039-alpha\lib\netstandard2.0\Microsoft.ServiceHub.Framework.dll</HintPath>
+    <Reference Include="Microsoft.ServiceHub.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ServiceHub.Framework.4.8.55\lib\net472\Microsoft.ServiceHub.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ComponentModelHost.17.0.255-preview-ga4c683bf62\lib\net472\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.ComponentModelHost.17.14.106\lib\net472\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.17.0.255-preview-ga4c683bf62\lib\net472\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.17.14.275\lib\net472\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.GraphModel, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.GraphModel.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.GraphModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.GraphModel.17.14.40260\lib\net472\Microsoft.VisualStudio.GraphModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ImageCatalog, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ImageCatalog.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.ImageCatalog.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.ImageCatalog.17.14.40260\lib\net472\Microsoft.VisualStudio.ImageCatalog.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.Imaging.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.17.14.40264\lib\net472\Microsoft.VisualStudio.Imaging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.17.14.40254\lib\net472\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Interop, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Interop.17.0.0-previews-3-31605-261\lib\net45\Microsoft.VisualStudio.Interop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Interop.17.14.40260\lib\net45\Microsoft.VisualStudio.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.17.0.0-previews-3-31605-261\lib\net45\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.17.14.40260\lib\net45\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ProjectAggregator, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.ProjectAggregator.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.ProjectAggregator.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.ProjectAggregator.17.14.40254\lib\net472\Microsoft.VisualStudio.ProjectAggregator.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.RemoteControl, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.RemoteControl.16.3.41\lib\net45\Microsoft.VisualStudio.RemoteControl.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.RemoteControl.16.3.52\lib\net45\Microsoft.VisualStudio.RemoteControl.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.RpcContracts, Version=17.0.50.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.RpcContracts.17.0.50-preview-0002-0010\lib\netstandard2.0\Microsoft.VisualStudio.RpcContracts.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.RpcContracts, Version=17.14.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.RpcContracts.17.14.20\lib\netstandard2.0\Microsoft.VisualStudio.RpcContracts.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.15.0.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.15.0.17.14.40264\lib\net472\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.17.14.40264\lib\net472\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Telemetry, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Telemetry.16.3.198\lib\net45\Microsoft.VisualStudio.Telemetry.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Telemetry, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Telemetry.17.14.18\lib\net45\Microsoft.VisualStudio.Telemetry.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Text.Data.17.0.255-preview-ga4c683bf62\lib\net472\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.Data.17.14.249\lib\net472\Microsoft.VisualStudio.Text.Data.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Threading.17.0.32-alpha\lib\net472\Microsoft.VisualStudio.Threading.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.17.14.15\lib\net472\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.17.0.0-previews-3-31605-261\lib\net472\Microsoft.VisualStudio.Utilities.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.17.14.40264\lib\net472\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities.Internal, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.Internal.16.3.23\lib\net45\Microsoft.VisualStudio.Utilities.Internal.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Utilities.Internal.16.3.90\lib\net45\Microsoft.VisualStudio.Utilities.Internal.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Validation, Version=16.10.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Validation.16.10.34\lib\netstandard2.0\Microsoft.VisualStudio.Validation.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Validation.17.13.22\lib\netstandard2.0\Microsoft.VisualStudio.Validation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Win32.Registry, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Registry.5.0.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
@@ -304,14 +301,20 @@
   <ItemGroup>
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\analyzers\dotnet\cs\Microsoft.CodeAnalysis.BannedApiAnalyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.10.10\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.10.10\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CSharp.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.dll" />
+    <Analyzer Include="..\packages\Microsoft.ServiceHub.Analyzers.4.8.55\analyzers\cs\Microsoft.ServiceHub.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.ServiceHub.Analyzers.4.8.55\analyzers\cs\Microsoft.ServiceHub.Analyzers.CSharp.dll" />
+    <Analyzer Include="..\packages\Microsoft.ServiceHub.Analyzers.4.8.55\analyzers\cs\Microsoft.ServiceHub.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.ServiceHub.Analyzers.4.8.55\analyzers\vb\Microsoft.ServiceHub.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.ServiceHub.Analyzers.4.8.55\analyzers\vb\Microsoft.ServiceHub.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.ServiceHub.Analyzers.4.8.55\analyzers\vb\Microsoft.ServiceHub.Analyzers.VisualBasic.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.17.7.105\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.17.7.105\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.CSharp.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\analyzers\vb\Microsoft.VisualStudio.Threading.Analyzers.VisualBasic.dll" />
   </ItemGroup>
   <PropertyGroup>
     <!--
@@ -361,15 +364,15 @@
     <PropertyGroup>
       <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.10.10\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.10.10\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\buildTransitive\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\buildTransitive\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.17.7.105\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.17.7.105\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.4194-preview4\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.17.14.2120\build\Microsoft.VSSDK.BuildTools.targets')" />
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.2\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.0.32-alpha\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.10.10\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.16.10.10\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\buildTransitive\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.17.14.15\buildTransitive\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.17.7.105\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.17.7.105\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
 </Project>

--- a/RazorGenerator.Tooling/app.config
+++ b/RazorGenerator.Tooling/app.config
@@ -24,11 +24,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-17.0.0.0" newVersion="17.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-17.14.0.0" newVersion="17.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-16.10.0.0" newVersion="16.10.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-17.0.0.0" newVersion="17.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -36,7 +36,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ServiceHub.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/RazorGenerator.Tooling/packages.config
+++ b/RazorGenerator.Tooling/packages.config
@@ -6,33 +6,33 @@
   <package id="Microsoft.Build.Framework" version="16.5.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.2" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net472" />
-  <package id="Microsoft.ServiceHub.Analyzers" version="3.0.1039-alpha" targetFramework="net472" />
-  <package id="Microsoft.ServiceHub.Client" version="3.0.1039-alpha" targetFramework="net472" />
-  <package id="Microsoft.ServiceHub.Framework" version="3.0.1039-alpha" targetFramework="net472" />
-  <package id="Microsoft.ServiceHub.Resources" version="3.0.1039-alpha" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.ComponentModelHost" version="17.0.255-preview-ga4c683bf62" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.CoreUtility" version="17.0.255-preview-ga4c683bf62" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.GraphModel" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.ImageCatalog" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Imaging" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Interop" version="17.0.0-previews-3-31605-261" targetFramework="net45" requireReinstallation="true" />
-  <package id="Microsoft.VisualStudio.OLE.Interop" version="17.0.0-previews-3-31605-261" targetFramework="net45" requireReinstallation="true" />
-  <package id="Microsoft.VisualStudio.ProjectAggregator" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.RemoteControl" version="16.3.41" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.RpcContracts" version="17.0.50-preview-0002-0010" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.SDK.Analyzers" version="16.10.10" targetFramework="net472" developmentDependency="true" />
-  <package id="Microsoft.VisualStudio.Shell.15.0" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Shell.Framework" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Shell.Interop" version="17.0.0-previews-3-31605-261" targetFramework="net45" requireReinstallation="true" />
-  <package id="Microsoft.VisualStudio.Telemetry" version="16.3.198" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Text.Data" version="17.0.255-preview-ga4c683bf62" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Threading" version="17.0.32-alpha" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="17.0.32-alpha" targetFramework="net472" developmentDependency="true" />
-  <package id="Microsoft.VisualStudio.Utilities" version="17.0.0-previews-3-31605-261" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Utilities.Internal" version="16.3.23" targetFramework="net472" />
-  <package id="Microsoft.VisualStudio.Validation" version="16.10.34" targetFramework="net472" />
-  <package id="Microsoft.VSSDK.BuildTools" version="17.0.4194-preview4" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.ServiceHub.Analyzers" version="4.8.55" targetFramework="net472" />
+  <package id="Microsoft.ServiceHub.Client" version="4.1.3102" targetFramework="net472" />
+  <package id="Microsoft.ServiceHub.Framework" version="4.8.55" targetFramework="net472" />
+  <package id="Microsoft.ServiceHub.Resources" version="4.6.2052" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.ComponentModelHost" version="17.14.106" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="17.14.275" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.GraphModel" version="17.14.40260" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.ImageCatalog" version="17.14.40260" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Imaging" version="17.14.40264" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="17.14.40254" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Interop" version="17.14.40260" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="17.14.40260" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.ProjectAggregator" version="17.14.40254" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.RemoteControl" version="16.3.52" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.RpcContracts" version="17.14.20" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.SDK.Analyzers" version="17.7.105" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.Shell.15.0" version="17.14.40264" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="17.14.40264" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="17.14.40260" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Telemetry" version="17.14.18" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Text.Data" version="17.14.249" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Threading" version="17.14.15" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="17.14.15" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.Utilities" version="17.14.40264" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Utilities.Internal" version="16.3.90" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Validation" version="17.13.22" targetFramework="net472" />
+  <package id="Microsoft.VSSDK.BuildTools" version="17.14.2120" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.Win32.Registry" version="5.0.0" targetFramework="net472" />
   <package id="Nerdbank.Streams" version="2.6.81" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />

--- a/RazorGenerator.Tooling/source.extension.vsixmanifest
+++ b/RazorGenerator.Tooling/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
   <Metadata>
-    <Identity Id="2FD58EB3-29A2-40A3-BE17-C024CA9A17A2" Version="1.13.0" Language="en-US" Publisher="RazorGenerator contributors" />
+    <Identity Id="2FD58EB3-29A2-40A3-BE17-C024CA9A17A2" Version="1.14.0" Language="en-US" Publisher="RazorGenerator contributors" />
     <DisplayName>Razor Generator</DisplayName>
     <Description>Generates source code from Razor files (.cshtml/.vbhtml files), allowing them to be compiled into your assemblies. Supports MVC, Web Pages and standalone templates.</Description>
     <MoreInfo>https://github.com/RazorGenerator/RazorGenerator</MoreInfo>
@@ -12,19 +12,19 @@
     <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community">
         <ProductArchitecture>x86</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[17.0,)" Id="Microsoft.VisualStudio.Community">
+    <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Community">
         <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
     <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro">
         <ProductArchitecture>x86</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[17.0,)" Id="Microsoft.VisualStudio.Pro">
+    <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Pro">
         <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
     <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise">
         <ProductArchitecture>x86</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[17.0,)" Id="Microsoft.VisualStudio.Enterprise">
+    <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Enterprise">
         <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
   </Installation>
@@ -33,6 +33,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="RazorGenerator.pkgdef" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,19.0)" />
   </Prerequisites>
 </PackageManifest>

--- a/build.ps1
+++ b/build.ps1
@@ -1,11 +1,33 @@
-$potentialMsBuildPaths = @(
-    [IO.Path]::Combine(${env:ProgramFiles(x86)}, "MsBuild", "12.0", "Bin"),
-    [IO.Path]::Combine(${env:ProgramFiles(x86)}, "MsBuild", "14.0", "Bin"),
-    [IO.Path]::Combine($env:Windir, "Microsoft.NET", "Framework", "v4.0.30319")
-)
-$msbuild = $potentialMsBuildPaths | Join-Path -ChildPath "msbuild.exe" | ? { Test-Path $_ } | Select -First 1
+# Locate MSBuild using vswhere (supports VS2022 / VS2026 and later)
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswhere)) {
+    $vswhere = "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe"
+}
 
-& $msbuild .nuget\nuget.targets /t:_DownloadNuGet /v:M
+if (Test-Path $vswhere) {
+    $vsInstallPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+    $msbuild = Join-Path $vsInstallPath "MSBuild\Current\Bin\MSBuild.exe"
+} else {
+    # Fallback: try well-known VS2022 / VS2026 paths
+    $potentialMsBuildPaths = @(
+        "${env:ProgramFiles}\Microsoft Visual Studio\2026\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2026\Professional\MSBuild\Current\Bin\MSBuild.exe",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2026\Community\MSBuild\Current\Bin\MSBuild.exe",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
+    )
+    $msbuild = $potentialMsBuildPaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+
+if (-not $msbuild -or -not (Test-Path $msbuild)) {
+    Write-Error "MSBuild not found. Please install Visual Studio 2022 or later."
+    exit 1
+}
+
+Write-Host "Using MSBuild: $msbuild"
+
+# Restore NuGet packages
 .nuget\NuGet.exe restore RazorGenerator.Tooling.sln
 .nuget\NuGet.exe restore RazorGenerator.Runtime.sln
 


### PR DESCRIPTION
## Summary
Upgrades the RazorGenerator VSIX extension to install and run in both Visual Studio 2022 (v17.x) and Visual Studio 2026 (v18.x).

## VSIX manifest (version 1.13.0 -> 1.14.0)
- Install target ranges changed from open-ended [17.0,) to [17.0,19.0) so the extension is offered to VS2022 and VS2026 but not beyond.
- Prerequisite range updated to [15.0,19.0).

## Package upgrades (RazorGenerator.Tooling)
All VS SDK NuGet packages moved from preview/alpha builds to the latest stable 17.14.x releases so a single binary works in both IDE versions:
- Microsoft.VSSDK.BuildTools 17.0.4194-preview4 -> 17.14.2120
- Microsoft.VisualStudio.Shell.15.0 17.0.x-preview -> 17.14.40264
- Microsoft.VisualStudio.Threading 17.0.x-preview -> 17.14.15
- Microsoft.VisualStudio.SDK.Analyzers -> 17.7.105
- Microsoft.ServiceHub.Framework 3.0.1039-alpha -> 4.8.55
- Microsoft.ServiceHub.Client -> 4.1.3102
- (and all other VS SDK transitive dependencies)

## Project file updates (RazorGenerator.Tooling.csproj)
- All HintPaths updated to the new package folder names.
- ServiceHub.Analyzers no longer ships a lib folder in v4; removed the stale <Reference> element, kept only the <Analyzer> items.
- Assembly version attributes updated for Telemetry, Validation, ServiceHub.Framework, and RpcContracts.
- Microsoft.VisualStudio.Threading.Analyzers 17.14.15 ships targets under buildTransitive\ instead of build\; paths updated accordingly.

## app.config (RazorGenerator.Tooling)
- Binding redirect for Microsoft.VisualStudio.Validation 16.10 -> 17.0.
- Binding redirect for Microsoft.ServiceHub.Framework 3.0 -> 4.0.
- Threading upper bound extended to 17.14.0.0.

## build.ps1
Replaced legacy hardcoded MSBuild 12/14 path lookup with vswhere.exe discovery, supporting VS2022 and VS2026 (and future versions).

## Solution file
Header updated to Visual Studio Version 17 / VisualStudioVersion 17.14.

## Infrastructure fixes
- .nuget/NuGet.targets: -o flag -> -OutputDirectory (NuGet.exe 6.x made the short flag ambiguous with the new -OutputFileNamesWithoutVersion).
- .nuget/NuGet.exe: added missing executable (was absent from the repo).

## Test fixes (RazorGenerator.Core.Test) - pre-existing failures All 33 tests (11 test names x 3 Razor runtimes) now pass. The v1 and v2 runtime tests were already broken before this PR:
- Added Microsoft.Web.Infrastructure as a direct reference so the DLL is copied to the test output directory.
- AfterBuild target copies Razor-1/MVC-3 DLLs to bin\v1\ and Razor-2/MVC-4 DLLs to bin\v2\ so they coexist with the v3 DLLs.
- Registered an AppDomain.AssemblyResolve handler in CoreTest's static constructor to route old-era assembly loads to the correct sub-directory. Uses Assembly.CodeBase (not Assembly.Location) to resolve the correct path when xunit shadow-copies the test assembly to a temp directory.