### PR TITLE
Add support for configurable generated file suffix

### DIFF
--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -44,6 +44,7 @@
         <RazorCodeGen ProjectRoot="$(MsBuildProjectDirectory)"
                                     FilesToPrecompile="@(RazorSrcFiles)"
                                     CodeGenDirectory="$(RazorViewsCodeGenDirectory)"
+									Suffix="$(Suffix)"
                                     RootNamespace="$(RootNamespace)">
             <Output TaskParameter="GeneratedFiles" ItemName="FilesGenerated" />
         </RazorCodeGen>

--- a/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
+++ b/RazorGenerator.MsBuild/RazorGenerator.MsBuild.targets
@@ -44,7 +44,7 @@
         <RazorCodeGen ProjectRoot="$(MsBuildProjectDirectory)"
                                     FilesToPrecompile="@(RazorSrcFiles)"
                                     CodeGenDirectory="$(RazorViewsCodeGenDirectory)"
-									Suffix="$(Suffix)"
+									Suffix="$(RazorFileSuffix)"
                                     RootNamespace="$(RootNamespace)">
             <Output TaskParameter="GeneratedFiles" ItemName="FilesGenerated" />
         </RazorCodeGen>

--- a/RazorGenerator.MsBuild/RazorGenerator.cs
+++ b/RazorGenerator.MsBuild/RazorGenerator.cs
@@ -26,7 +26,7 @@ namespace RazorGenerator.MsBuild
         [Required]
         public string CodeGenDirectory { get; set; }
 
-        public string Suffix { get; set; }
+        public string Suffix { get; set; } = string.Empty;
         [Output]
         public ITaskItem[] GeneratedFiles
         {


### PR DESCRIPTION
This change introduces a new `Suffix `property for the `RazorCodeGen `MSBuild task, allowing projects to control the suffix used for generated Razor code files.

When no suffix is specified, the existing naming behavior is preserved.

This enables scenarios where projects want to generate files such as:
```
Index.generated.cs
Index.g.cs
Index.view.cs
```
while maintaining compatibility with the current output format.